### PR TITLE
add ProjectGuid to ScintillaNET_FindReplaceDialog.csproj

### DIFF
--- a/ScintillaNet_FindReplaceDialog/ScintillaNET_FindReplaceDialog.csproj
+++ b/ScintillaNet_FindReplaceDialog/ScintillaNET_FindReplaceDialog.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <ProjectGuid>{7FA22A4B-FB50-4D65-B79F-F3EEDB413C41}</ProjectGuid>
     <RootNamespace>ScintillaNET_FindReplaceDialog</RootNamespace>
     <TargetFrameworks>netcoreapp3.1;net6.0-windows;net45</TargetFrameworks>
     <AssemblyTitle>ScintillaNet FindReplaceDialog</AssemblyTitle>


### PR DESCRIPTION
This is needed for [WiX project harvesting](https://docs.firegiant.com/wix/tools/heat/#using-harvestproject-to-harvest-output-from-a-project) so that generated IDs are unique, although specifying a ProjectGUID is optional in SDK-style projects.

The value is taken from the solution file.